### PR TITLE
Fix php warning if determineClickedIcon returns -1 due to invalid coo…

### DIFF
--- a/src/Challenge/Challenge.php
+++ b/src/Challenge/Challenge.php
@@ -232,7 +232,7 @@ class Challenge
         $clickedPosition = $this->determineClickedIcon($x, $y, $width, count($this->session->icons));
 
         // Check if the selection matches the position from the session.
-        if ($this->session->icons[$clickedPosition] === $this->session->correctId) {
+        if (isset($this->session->icons[$clickedPosition]) && $this->session->icons[$clickedPosition] === $this->session->correctId) {
 
             // Mark the challenge as completed.
             $this->markChallengeCompleted();


### PR DESCRIPTION
…rdinates.

In some cases it seems that `determineClickedIcon` returns `-1` which results in a php warning as `$this->session->icons[-1]` does not exist